### PR TITLE
Normalise format/indentation of source code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,11 @@
+plugins {
+    id 'java'
+    id "com.diffplug.gradle.spotless" version "3.10.0"
+}
+
 wrapper {
     gradleVersion = '4.7'
 }
-
-apply plugin: 'java'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -14,6 +17,14 @@ repositories {
 
 dependencies {
     compile ('org.apache.commons:commons-compress:1.13')
+}
+
+spotless {
+    java {
+        licenseHeaderFile "$projectDir/gradle/spotless/license.java"
+
+        googleJavaFormat().style('AOSP')
+    }
 }
 
 task downloadGeckoWebdrivers(type: JavaExec, dependsOn: 'classes') {

--- a/gradle/spotless/license.java
+++ b/gradle/spotless/license.java
@@ -1,0 +1,19 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright $YEAR The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/src/main/java/org/zaproxy/libs/DownloadTools.java
+++ b/src/main/java/org/zaproxy/libs/DownloadTools.java
@@ -27,12 +27,10 @@ import java.net.URL;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
 public class DownloadTools {
-
 
     public static void downloadDriver(String urlStr, String destDir, String destFile) {
         File dest = new File(destDir + destFile);
@@ -42,7 +40,8 @@ public class DownloadTools {
         }
         File parent = dest.getParentFile();
         if (!parent.exists() && !parent.mkdirs()) {
-            System.out.println("Failed to create directory : " + dest.getParentFile().getAbsolutePath());
+            System.out.println(
+                    "Failed to create directory : " + dest.getParentFile().getAbsolutePath());
         }
         byte[] buffer = new byte[1024];
         if (urlStr.endsWith(".zip")) {

--- a/src/main/java/org/zaproxy/libs/WebdriverDownloadChrome.java
+++ b/src/main/java/org/zaproxy/libs/WebdriverDownloadChrome.java
@@ -22,9 +22,10 @@ package org.zaproxy.libs;
 public class WebdriverDownloadChrome {
 
     /**
-     * The webdriver files are not held in the repo to prevent space problems. Run the program to download the files before
-     * building the add-on. It will need to be changed whenever there are new versions.
-     * 
+     * The webdriver files are not held in the repo to prevent space problems. Run the program to
+     * download the files before building the add-on. It will need to be changed whenever there are
+     * new versions.
+     *
      * @param args
      */
     public static void main(String[] args) {
@@ -34,19 +35,25 @@ public class WebdriverDownloadChrome {
 
         // Windows
         DownloadTools.downloadDriver(
-                "https://chromedriver.storage.googleapis.com/" + VERSION + "/chromedriver_win32.zip",
+                "https://chromedriver.storage.googleapis.com/"
+                        + VERSION
+                        + "/chromedriver_win32.zip",
                 "files/webdriver/windows/32/",
                 "chromedriver.exe");
 
         // Linux
         DownloadTools.downloadDriver(
-                "https://chromedriver.storage.googleapis.com/" + VERSION + "/chromedriver_linux64.zip",
+                "https://chromedriver.storage.googleapis.com/"
+                        + VERSION
+                        + "/chromedriver_linux64.zip",
                 "files/webdriver/linux/64/",
                 "chromedriver");
 
         // MacOS
         DownloadTools.downloadDriver(
-                "https://chromedriver.storage.googleapis.com/" + VERSION + "/chromedriver_mac64.zip",
+                "https://chromedriver.storage.googleapis.com/"
+                        + VERSION
+                        + "/chromedriver_mac64.zip",
                 "files/webdriver/macos/64/",
                 "chromedriver");
     }

--- a/src/main/java/org/zaproxy/libs/WebdriverDownloadGecko.java
+++ b/src/main/java/org/zaproxy/libs/WebdriverDownloadGecko.java
@@ -22,9 +22,10 @@ package org.zaproxy.libs;
 public class WebdriverDownloadGecko {
 
     /**
-     * The webdriver files are not held in the repo to prevent space problems. Run the program to download the files before
-     * building the add-on. It will need to be changed whenever there are new versions.
-     * 
+     * The webdriver files are not held in the repo to prevent space problems. Run the program to
+     * download the files before building the add-on. It will need to be changed whenever there are
+     * new versions.
+     *
      * @param args
      */
     public static void main(String[] args) {
@@ -34,31 +35,46 @@ public class WebdriverDownloadGecko {
 
         // Windows
         DownloadTools.downloadDriver(
-                "https://github.com/mozilla/geckodriver/releases/download/" + VERSION + "/geckodriver-" + VERSION
+                "https://github.com/mozilla/geckodriver/releases/download/"
+                        + VERSION
+                        + "/geckodriver-"
+                        + VERSION
                         + "-win32.zip",
                 "files/webdriver/windows/32/",
                 "geckodriver.exe");
         DownloadTools.downloadDriver(
-                "https://github.com/mozilla/geckodriver/releases/download/" + VERSION + "/geckodriver-" + VERSION
+                "https://github.com/mozilla/geckodriver/releases/download/"
+                        + VERSION
+                        + "/geckodriver-"
+                        + VERSION
                         + "-win64.zip",
                 "files/webdriver/windows/64/",
                 "geckodriver.exe");
 
         // Linux
         DownloadTools.downloadDriver(
-                "https://github.com/mozilla/geckodriver/releases/download/" + VERSION + "/geckodriver-" + VERSION
+                "https://github.com/mozilla/geckodriver/releases/download/"
+                        + VERSION
+                        + "/geckodriver-"
+                        + VERSION
                         + "-linux32.tar.gz",
                 "files/webdriver/linux/32/",
                 "geckodriver");
         DownloadTools.downloadDriver(
-                "https://github.com/mozilla/geckodriver/releases/download/" + VERSION + "/geckodriver-" + VERSION
+                "https://github.com/mozilla/geckodriver/releases/download/"
+                        + VERSION
+                        + "/geckodriver-"
+                        + VERSION
                         + "-linux64.tar.gz",
                 "files/webdriver/linux/64/",
                 "geckodriver");
 
         // MacOS
         DownloadTools.downloadDriver(
-                "https://github.com/mozilla/geckodriver/releases/download/" + VERSION + "/geckodriver-" + VERSION
+                "https://github.com/mozilla/geckodriver/releases/download/"
+                        + VERSION
+                        + "/geckodriver-"
+                        + VERSION
                         + "-macos.tar.gz",
                 "files/webdriver/macos/64/",
                 "geckodriver");

--- a/src/main/java/org/zaproxy/libs/WebdriverDownloadIE.java
+++ b/src/main/java/org/zaproxy/libs/WebdriverDownloadIE.java
@@ -22,9 +22,10 @@ package org.zaproxy.libs;
 public class WebdriverDownloadIE {
 
     /**
-     * The webdriver files are not held in the repo to prevent space problems. Run the program to download the files before
-     * building the add-on. It will need to be changed whenever there are new versions.
-     * 
+     * The webdriver files are not held in the repo to prevent space problems. Run the program to
+     * download the files before building the add-on. It will need to be changed whenever there are
+     * new versions.
+     *
      * @param args
      */
     public static void main(String[] args) {
@@ -35,12 +36,20 @@ public class WebdriverDownloadIE {
         final String LONG_VERSION = "3.7.0";
 
         DownloadTools.downloadDriver(
-                "http://selenium-release.storage.googleapis.com/" + SHORT_VERSION + "/IEDriverServer_Win32_" + LONG_VERSION + ".zip",
+                "http://selenium-release.storage.googleapis.com/"
+                        + SHORT_VERSION
+                        + "/IEDriverServer_Win32_"
+                        + LONG_VERSION
+                        + ".zip",
                 "files/webdriver/windows/32/",
                 "IEDriverServer.exe");
 
         DownloadTools.downloadDriver(
-                "http://selenium-release.storage.googleapis.com/" + SHORT_VERSION + "/IEDriverServer_x64_" + LONG_VERSION + ".zip",
+                "http://selenium-release.storage.googleapis.com/"
+                        + SHORT_VERSION
+                        + "/IEDriverServer_x64_"
+                        + LONG_VERSION
+                        + ".zip",
                 "files/webdriver/windows/64/",
                 "IEDriverServer.exe");
     }


### PR DESCRIPTION
Set up the Spotless plugin to check/enforce the format/indentation of
the whole source code, currently set to use Google Java Style (AOSP).
Also, ensure all Java source files have the expected license header.