### PR TITLE
Update dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile ('org.apache.commons:commons-compress:1.13')
+    compile ('org.apache.commons:commons-compress:1.18')
 }
 
 spotless {


### PR DESCRIPTION
Update Commons Compress to latest version 1.18, which addresses DoS
vulnerabilities.

Thanks to `snyk.io`.